### PR TITLE
Create a new iTerm 3 window if there's no current window

### DIFF
--- a/Classes/ElasticsAppDelegate.m
+++ b/Classes/ElasticsAppDelegate.m
@@ -1235,6 +1235,9 @@ static NSImage *_brImage;
                     // for iTerm 3+
                     new = [NSString stringWithFormat:
                            @"activate\n"
+                           @"if current window is missing value then\n"
+                           @"   create window with default profile\n"
+                           @"end if\n"
                            @"tell current window\n"
                            @"    set newTab to create tab with default profile\n"
                            @"    tell newTab\n"


### PR DESCRIPTION
Fix a bug that iTerm will not create a new tab when using 'Open new tabs instead of new windows' option and there's no active window.
